### PR TITLE
Página de cadastro de leads

### DIFF
--- a/src/components/Checkbox/index.jsx
+++ b/src/components/Checkbox/index.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import CheckboxWrapper, { Input } from './styles';
+
+export default function Checkbox({ option }) {
+  return (
+    <CheckboxWrapper>
+      <Input type="checkbox" />
+      {option}
+    </CheckboxWrapper>
+  );
+}

--- a/src/components/Checkbox/styles.js
+++ b/src/components/Checkbox/styles.js
@@ -1,0 +1,23 @@
+import styled from 'styled-components';
+
+const CheckboxWrapper = styled.label`
+  display: flex;
+  align-items: center;
+  padding: 5px 0;
+  cursor: pointer;
+  transition: 0.3s color;
+
+  @media (min-width: 600px) {
+    &:hover {
+      color: ${({ theme }) => theme.accent};
+    }
+  }
+`;
+
+export const Input = styled.input`
+  width: 15px;
+  height: 15px;
+  margin-right: 5px;
+`;
+
+export default CheckboxWrapper;

--- a/src/components/CheckboxList/index.jsx
+++ b/src/components/CheckboxList/index.jsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import Checkbox from '../Checkbox';
+import CheckboxListWrapper, { Boxes } from './styles';
+
+export default function CheckboxList({ title, options }) {
+  return (
+    <CheckboxListWrapper>
+      <p>{title}:</p>
+
+      <Boxes>
+        {
+          options.map((option, index) => (
+            <Checkbox key={index} option={option} />
+          ))
+        }
+      </Boxes>
+    </CheckboxListWrapper>
+  );
+}

--- a/src/components/CheckboxList/styles.js
+++ b/src/components/CheckboxList/styles.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components';
+
+const CheckboxListWrapper = styled.div`
+  margin-top: 20px;
+`;
+
+export const Boxes = styled.ul`
+  display: grid;
+  grid-template-columns: 50% 50%;
+  align-items: center;
+  margin-top: 5px;
+  
+  @media (max-width: 500px) {
+    grid-template-columns: 100%;
+  }
+`;
+
+export default CheckboxListWrapper;

--- a/src/components/LeadsList/index.jsx
+++ b/src/components/LeadsList/index.jsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { ChevronDown, CornerRightUp } from 'react-feather';
-import LeadsListWrapper, { Amount, Details, Item, Title } from './styles';
+import LeadsListWrapper, { Amount, Details, Item, Header, Title } from './styles';
 
 export default function LeadsList({ title, itemsAreBlocked = false }) {
   const icon = <CornerRightUp size={20} />;
 
   return (
     <LeadsListWrapper>
-      <Title>
-        {title}
+      <Header>
+        <Title>{title}</Title>
 
         <Details>
           <Amount>3</Amount>
           <button><ChevronDown /></button>
         </Details>
-      </Title>
+      </Header>
 
       <ul>
         <Item isBlocked={itemsAreBlocked}>Org. Internacionais {icon}</Item>

--- a/src/components/LeadsList/styles.js
+++ b/src/components/LeadsList/styles.js
@@ -26,21 +26,27 @@ const LeadsListWrapper = styled.article`
   }
 `;
 
-export const Title = styled.p`
+export const Header = styled.header`
   flex-grow: 1;
   padding: 10px 20px;
   margin-bottom: 15px;
   border-radius: 5px;
   background-color: ${({ theme }) => theme.sectionBackground};
-  font-weight: 500;
-  text-align: center;
   
   @media (max-width: 800px) {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    text-align: left;
     cursor: pointer;
+  }
+`;
+
+export const Title = styled.p`
+  font-weight: 500;
+  text-align: center;
+
+  @media (max-width: 800px) {
+    text-align: left;
   }
 `;
 

--- a/src/pages/NewLead/index.jsx
+++ b/src/pages/NewLead/index.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Header from '../../components/Header';
+import Main from '../../components/Main';
+import Form from '../../components/Form';
+import Field from '../../components/Field';
+import PrimaryButton from '../../components/PrimaryButton';
+import CheckboxList from '../../components/CheckboxList';
+import { opportunities } from '../../static/lead';
+
+export default function NewLead() {
+  return (
+    <React.Fragment>
+      <Header title="Novo Lead" />
+
+      <Main>
+        <Form title="Informações do lead">
+          <Field label="Nome" placeholder="Nome do lead" />
+          <Field label="Telefone" placeholder="Digite apenas números" type="tel" />
+          <Field label="E-mail" placeholder="E-mail do lead" type="email" />
+
+          <CheckboxList title="Oportunidades" options={opportunities} />
+
+          <PrimaryButton text="Salvar" />
+        </Form>
+      </Main>
+    </React.Fragment>
+  );
+}

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import Dashboard from './pages/Dashboard';
 import Login from './pages/Login';
+import NewLead from './pages/NewLead';
 
 export default function AppRoutes() {
   return (
@@ -9,6 +10,7 @@ export default function AppRoutes() {
       <Routes>
         <Route path="/" element={<Login />} />
         <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/novo-lead" element={<NewLead />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/static/lead.js
+++ b/src/static/lead.js
@@ -1,0 +1,6 @@
+export const opportunities = [
+  'RPA',
+  'Analytics',
+  'Produto digital',
+  'BPM',
+];


### PR DESCRIPTION
Este PR implementa a versão estática (apenas interface, sem ações) da página de cadastro de *leads*.

### Capturas de tela:
| Mobile | Desktop |
| --- | --- |
| ![mobile](https://user-images.githubusercontent.com/63798776/159983067-63bee99f-948b-486e-ad84-de1a8375bf85.png) | ![desktop](https://user-images.githubusercontent.com/63798776/159983071-6a7f434b-363d-475a-a973-97a21a3123d8.png) |