### PR TITLE
Listagem dos leads salvos

### DIFF
--- a/src/components/LeadsGrid/index.jsx
+++ b/src/components/LeadsGrid/index.jsx
@@ -1,13 +1,36 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import LeadsList from '../LeadsList';
 import LeadsGridWrapper from './styles';
+import { getLeads } from '../../controllers/leadController';
 
 export default function LeadsGrid() {
+  const [leads, setLeads] = useState([]);
+
+  useEffect(() => {
+    const savedLeads = getLeads();
+
+    if (savedLeads) {
+      setLeads(savedLeads);
+    }
+  }, []);
+
   return (
     <LeadsGridWrapper>
-      <LeadsList title="Cliente em Potencial" />
-      <LeadsList title="Dados Confirmados" />
-      <LeadsList title="Reunião Agendada" itemsAreBlocked />
+      <LeadsList
+        title="Cliente em Potencial"
+        items={leads.potential}
+      />
+
+      <LeadsList
+        title="Dados Confirmados"
+        items={leads.confirmedData}
+      />
+
+      <LeadsList
+        title="Reunião Agendada"
+        itemsAreBlocked
+        items={leads.scheduledMeeting}
+      />
     </LeadsGridWrapper>
   );
 }

--- a/src/components/LeadsGrid/styles.js
+++ b/src/components/LeadsGrid/styles.js
@@ -3,7 +3,6 @@ import styled from 'styled-components';
 const LeadsGridWrapper = styled.section`
   display: flex;
   justify-content: space-between;
-  align-items: center;
   
   @media (max-width: 800px) {
     flex-direction: column-reverse;

--- a/src/components/LeadsList/index.jsx
+++ b/src/components/LeadsList/index.jsx
@@ -1,26 +1,55 @@
-import React from 'react';
-import { ChevronDown, CornerRightUp } from 'react-feather';
-import LeadsListWrapper, { Amount, Details, Item, Header, Title } from './styles';
+import React, { useEffect, useState } from 'react';
+import { ChevronDown, ChevronRight, CornerRightUp } from 'react-feather';
+import LeadsListWrapper, { Amount, Details, Item, Header, Title, List } from './styles';
 
-export default function LeadsList({ title, itemsAreBlocked = false }) {
+export default function LeadsList({ title, items, itemsAreBlocked = false }) {
+  const [amount, setAmount] = useState(0);
+  const [listIsVisible, setListIsVisible] = useState(false);
+  const [listIcon, setListIcon] = useState(<ChevronRight />);
   const icon = <CornerRightUp size={20} />;
+
+  function toggleListVisibility() {
+    if (amount > 0) {
+      setListIsVisible(!listIsVisible);
+    }
+  }
+
+  useEffect(() => {
+    if (items) {
+      setAmount(items.length);
+    }
+  }, [items]);
+
+  useEffect(() => {
+    if (amount > 0) {
+      setListIsVisible(true);
+    }
+  }, [amount]);
+
+  useEffect(() => {
+    setListIcon(listIsVisible ? <ChevronDown /> : <ChevronRight />);
+  }, [listIsVisible]);
 
   return (
     <LeadsListWrapper>
-      <Header>
+      <Header onClick={toggleListVisibility}>
         <Title>{title}</Title>
 
         <Details>
-          <Amount>3</Amount>
-          <button><ChevronDown /></button>
+          <Amount>{amount}</Amount>
+          <button>{listIcon}</button>
         </Details>
       </Header>
 
-      <ul>
-        <Item isBlocked={itemsAreBlocked}>Org. Internacionais {icon}</Item>
-        <Item isBlocked={itemsAreBlocked}>Musc. Sound Live Cmp {icon}</Item>
-        <Item isBlocked={itemsAreBlocked}>Ind. Farm. LTDA {icon}</Item>
-      </ul>
+      <List isVisible={listIsVisible}>
+        {
+          items && items.map(item => (
+            <Item isBlocked={itemsAreBlocked} key={item.email}>
+              {item.name} {icon}
+            </Item>
+          ))
+        }
+      </List>
     </LeadsListWrapper>
   );
 }

--- a/src/components/LeadsList/styles.js
+++ b/src/components/LeadsList/styles.js
@@ -1,5 +1,4 @@
-import styled from 'styled-components';
-import { css } from 'styled-components';
+import styled, { css } from 'styled-components';
 
 function buildItemTransition({ isBlocked }) {
   return !isBlocked && css`
@@ -65,6 +64,12 @@ export const Amount = styled.span`
   margin-right: 5px;
   font-weight: 500;
   color: ${({ theme }) => theme.accent};
+`;
+
+export const List = styled.ul`
+  @media (max-width: 800px) {
+    ${({ isVisible }) => !isVisible && css`display: none;`}
+  }
 `;
 
 export const Item = styled.li`


### PR DESCRIPTION
Este PR implementa o carregamento dos *leads* (salvos no *localStorage*) na *dashboard* e a alteração da visibilidade das listas de *leads*, assim como a contagem dinâmica dos items da mesma.

### Captura de tela:
| Exemplo |
| --- |
| ![list](https://user-images.githubusercontent.com/63798776/160262491-40fdc397-0918-46e4-a15c-29ed1081d1fe.png) |